### PR TITLE
Configure 30s default jitter in docker watcher

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -30,7 +30,7 @@
                 "lokijs": "1.5.12",
                 "mqtt": "5.10.3",
                 "nocache": "4.0.0",
-                "node-cron": "3.0.3",
+                "node-cron": "4.1.0",
                 "node-telegram-bot-api": "0.66.0",
                 "nodemailer": "6.9.16",
                 "openid-client": "4.9.1",
@@ -6998,24 +6998,12 @@
             }
         },
         "node_modules/node-cron": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.3.tgz",
-            "integrity": "sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.1.0.tgz",
+            "integrity": "sha512-OS+3ORu+h03/haS6Di8Qr7CrVs4YaKZZOynZwQpyPZDnR3tqRbwJmuP2gVR16JfhLgyNlloAV1VTrrWlRogCFA==",
             "license": "ISC",
-            "dependencies": {
-                "uuid": "8.3.2"
-            },
             "engines": {
                 "node": ">=6.0.0"
-            }
-        },
-        "node_modules/node-cron/node_modules/uuid": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/node-int64": {

--- a/app/package.json
+++ b/app/package.json
@@ -36,7 +36,7 @@
         "lokijs": "1.5.12",
         "mqtt": "5.10.3",
         "nocache": "4.0.0",
-        "node-cron": "3.0.3",
+        "node-cron": "4.1.0",
         "node-telegram-bot-api": "0.66.0",
         "nodemailer": "6.9.16",
         "openid-client": "4.9.1",

--- a/app/watchers/providers/docker/Docker.js
+++ b/app/watchers/providers/docker/Docker.js
@@ -253,6 +253,7 @@ class Docker extends Component {
             certfile: this.joi.string(),
             keyfile: this.joi.string(),
             cron: joi.string().cron().default('0 * * * *'),
+            jitter: this.joi.number().integer().min(0).default(30000),
             watchbydefault: this.joi.boolean().default(true),
             watchall: this.joi.boolean().default(false),
             watchdigest: this.joi.any(),
@@ -274,6 +275,7 @@ class Docker extends Component {
         this.log.info(`Cron scheduled (${this.configuration.cron})`);
         this.watchCron = cron.schedule(this.configuration.cron, () =>
             this.watchFromCron(),
+            { maxRandomDelay: this.configuration.jitter },
         );
 
         // Force watchatstart value based on the state store (empty or not)

--- a/app/watchers/providers/docker/Docker.test.js
+++ b/app/watchers/providers/docker/Docker.test.js
@@ -44,6 +44,7 @@ const configurationValid = {
     watchall: false,
     watchevents: true,
     cron: '0 * * * *',
+    jitter: 30000,
     watchatstart: true,
 };
 


### PR DESCRIPTION
Default 30sec. Configurable by setting environment variable `WUD_WATCHER_LOCAL_JITTER` which is in millis.